### PR TITLE
development

### DIFF
--- a/src/Fame-ImportExport/Boolean.extension.st
+++ b/src/Fame-ImportExport/Boolean.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Boolean }
+
+{ #category : #'*Fame-ImportExport' }
+Boolean >> msePrintOn: aStream [
+	self printOn: aStream
+]

--- a/src/Fame-ImportExport/Number.extension.st
+++ b/src/Fame-ImportExport/Number.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Number }
+
+{ #category : #'*Fame-ImportExport' }
+Number >> msePrintOn: aStream [
+	self printOn: aStream
+]

--- a/src/Fame-ImportExport/Object.extension.st
+++ b/src/Fame-ImportExport/Object.extension.st
@@ -15,5 +15,5 @@ Object >> isDanglingReference [
 
 { #category : #'*Fame-ImportExport' }
 Object >> msePrintOn: aStream [
-	self printOn: aStream
+	self error: 'This type of object cannot be exported in a mse: ' , self class printString
 ]

--- a/src/Fame-ImportExport/String.extension.st
+++ b/src/Fame-ImportExport/String.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #String }
+
+{ #category : #'*Fame-ImportExport' }
+String >> msePrintOn: aStream [
+	self printOn: aStream
+]

--- a/src/Fame-Tests/FMExporterTest.class.st
+++ b/src/Fame-Tests/FMExporterTest.class.st
@@ -39,3 +39,18 @@ FMExporterTest >> testExportedModelIsTheSameAsBeforeExport [
 	self assert: metamodel classes size equals: 3.
 	self assert: metamodel properties size equals: 6
 ]
+
+{ #category : #tests }
+FMExporterTest >> testMSEExportWithWrongTypeRaiseError [
+	| printer model |
+	model := FMModel withMetamodel: FMEquationSystemExample createMetamodel.
+
+	model
+		add:
+			(EQNumerical new
+				number: DateAndTime now; "Here a number primitive is expected but a date and time is passed."
+				yourself).
+
+	printer := FMMSEPrinter onString.
+	self should: [ model exportWithPrinter: printer ] raise: Error
+]


### PR DESCRIPTION
Add explicit error if we export the wrong type of entity in Fame.